### PR TITLE
fix: Get sensai work on windows (native)

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,6 +4,6 @@
     "dev": "sensai dev"
   },
   "dependencies": {
-    "sensai": "^1.3.2"
+    "sensai": "^1.3.4"
   }
 }

--- a/packages/sensai/.swcrc
+++ b/packages/sensai/.swcrc
@@ -12,7 +12,7 @@
   "jsc": {
     "target": "es2022",
     "loose": true,
-    "baseUrl": ".",
+    "baseUrl": "./",
     "parser": {
       "syntax": "typescript",
       "dynamicImport": true,

--- a/packages/sensai/src/commands/dev.ts
+++ b/packages/sensai/src/commands/dev.ts
@@ -1,3 +1,4 @@
+import { sep, posix } from "path";
 import httpServer from "@/src/lib/server/http";
 import { type SensaiConfig } from "@/src/types";
 import router from "@/src/lib/router";
@@ -14,7 +15,8 @@ export default async (options: SensaiConfig) => {
   const routes = await router(cwdPath);
   const entries = await walker(options.apiDir);
   for await (const filePath of entries) {
-    routes.add(filePath);
+    const normalizedPath = '/' + posix.join(...filePath.split(sep));
+    routes.add(normalizedPath);
   }
   if (options.watch) await watcher(options.apiDir, routes);
   compiler(cwdPath, options.apiDir);
@@ -29,5 +31,6 @@ export default async (options: SensaiConfig) => {
       // TODO documentation
     }
   }, options.port);
+  console.log(`Sensai Server Started on Port: ${options.port}`);
   return server;
 };


### PR DESCRIPTION
1. Added a log to indicate the server has started (I got a little confused)
2. Changed .swcrc to use './' instead of '.' as basePath. As '.' causes a bug on Windows only.
3. Normalized the paths in the routes to support windows native.