### PR TITLE
feat(prompt): Create json schema off interpolated parameters in prompt

### DIFF
--- a/examples/ai/orchestrator/api/stocks/prompt.md
+++ b/examples/ai/orchestrator/api/stocks/prompt.md
@@ -1,1 +1,1 @@
-#{prompt}
+stock price for #{company}

--- a/examples/ai/orchestrator/api/weather/prompt.md
+++ b/examples/ai/orchestrator/api/weather/prompt.md
@@ -1,1 +1,1 @@
-#{prompt}
+give me the weather in #{city}

--- a/packages/sensai/src/lib/compiler/markdown.ts
+++ b/packages/sensai/src/lib/compiler/markdown.ts
@@ -68,6 +68,8 @@ export const getPromptTypescript = (
   const { content, data } = matter(fileContent);
   // TODO we should provide a way for a prompt to inject the result of an
   // orhter prompt declaratively
+
+  // TODO we should find a better way for passthrough prompts
   return `
     import template from 'sensai/template';
     import ai, { tool } from 'sensai/dist/src/utils/ai'; // TODO this should be cleaner
@@ -81,14 +83,16 @@ export const getPromptTypescript = (
     `
       )
       .join("\n")}
-    const prompt = template(${JSON.stringify(content)})
+    const content = ${JSON.stringify(content.trim())};
+    const prompt = template(content);
+    const input = content !== '#{prompt}' ? prompt.schema : ${JSON.stringify(defaultSchema)};
     export default guard(async (data) => {
       const text = await prompt(data);
       return await ai(text, { tools });
     }, { 
       description: ${JSON.stringify(data.description)},
-      input: ${JSON.stringify(defaultSchema)},
-    })
+      input,
+    });
   `;
 };
 

--- a/packages/sensai/src/utils/template.test.ts
+++ b/packages/sensai/src/utils/template.test.ts
@@ -1,300 +1,301 @@
-import test from 'node:test'
-import assert from 'node:assert'
-import { Readable, Writable } from 'node:stream'
-import template from './template'
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { Readable, Writable } from "node:stream";
+import template, { compile } from "./template";
 
-test('Basic string template', async (t) => {
-  const render = template('Hello #{name}!')
-  const result = await render({ name: 'World' })
-  assert.strictEqual(result, 'Hello World!')
-})
+console.log("*****", compile("Hello #{name + child.age}!")[2]);
 
-test('Template literal syntax', async (t) => {
-  const name = 'World'
-  const tmpl = template`Hello ${name}!`
-  const result = await tmpl
-  assert.strictEqual(result, 'Hello World!')
-})
+describe("template", () => {
+  it("Basic string template", async (t) => {
+    const render = template("Hello #{name}!");
+    const result = await render({ name: "World" });
+    assert.strictEqual(result, "Hello World!");
+  });
 
-test('Multiple placeholders', async (t) => {
-  const render = template('Hello #{firstName} #{lastName}!')
-  const result = await render({ firstName: 'John', lastName: 'Doe' })
-  assert.strictEqual(result, 'Hello John Doe!')
-})
+  it("Template literal syntax", async (t) => {
+    const name = "World";
+    const result = await template`Hello ${name}!`;
+    assert.strictEqual(result, "Hello World!");
+  });
 
-test('Expression evaluation', async (t) => {
-  const render = template('The answer is #{a + b}!')
-  const result = await render({ a: 20, b: 22 })
-  assert.strictEqual(result, 'The answer is 42!')
-})
+  it("Multiple placeholders", async (t) => {
+    const render = template("Hello #{firstName} #{lastName}!");
+    const result = await render({ firstName: "John", lastName: "Doe" });
+    assert.strictEqual(result, "Hello John Doe!");
+  });
 
-test('Using array index', async (t) => {
-  const render = template('First item: #{items[0]}')
-  const result = await render({ items: ['apple', 'banana', 'cherry'] })
-  assert.strictEqual(result, 'First item: apple')
-})
+  it("Expression evaluation", async (t) => {
+    const render = template("The answer is #{a + b}!");
+    const result = await render({ a: 20, b: 22 });
+    assert.strictEqual(result, "The answer is 42!");
+  });
 
-test('Nested properties', async (t) => {
-  const render = template('Welcome, #{user.profile.name}!')
-  const result = await render({ 
-    user: { 
-      profile: { 
-        name: 'Alice' 
-      } 
-    } 
-  })
-  assert.strictEqual(result, 'Welcome, Alice!')
-})
+  it("Using array index", async (t) => {
+    const render = template("First item: #{items[0]}");
+    const result = await render({ items: ["apple", "banana", "cherry"] });
+    assert.strictEqual(result, "First item: apple");
+  });
 
-test('Function execution', async (t) => {
-  const render = template('Calculated: #{calculate()}')
-  const result = await render({ 
-    calculate: () => 100 * 2
-  })
-  assert.strictEqual(result, 'Calculated: 200')
-})
+  it("Nested properties", async (t) => {
+    const render = template("Welcome, #{user.profile.name}!");
+    const result = await render({
+      user: {
+        profile: {
+          name: "Alice",
+        },
+      },
+    });
+    assert.strictEqual(result, "Welcome, Alice!");
+  });
 
-test('Missing data should render empty string', async (t) => {
-  const render = template('Value: #{missing}!')
-  const result = await render({})
-  assert.strictEqual(result, 'Value: !')
-})
+  it("Function execution", async (t) => {
+    const render = template("Calculated: #{calculate()}");
+    const result = await render({
+      calculate: () => 100 * 2,
+    });
+    assert.strictEqual(result, "Calculated: 200");
+  });
 
-test('Streaming capability - pipe to another stream', async (t) => {
-  const render = template('Hello #{name}!')
-  const stream = render({ name: 'Stream' })
-  
-  // Create a writable stream to collect data
-  let collected = ''
-  const writable = new Writable({
-    write(chunk, encoding, callback) {
-      collected += chunk.toString()
-      callback()
-    }
-  })
-  
-  // Pipe and wait for completion
-  stream.pipe(writable)
-  await new Promise(resolve => stream.on('end', resolve))
-  
-  assert.strictEqual(collected, 'Hello Stream!')
-})
+  it("Missing data should render empty string", async (t) => {
+    const render = template("Value: #{missing}!");
+    const result = await render({});
+    assert.strictEqual(result, "Value: !");
+  });
 
-test('Stream as a placeholder value', async (t) => {
-  const render = template('Content: #{content}')
-  
-  const contentStream = new Readable({
-    read() {
-      this.push('streamed content')
-      this.push(null)
-    }
-  })
-  
-  const result = await render({ content: contentStream })
-  assert.strictEqual(result, 'Content: streamed content')
-})
+  it("Streaming capability - pipe to another stream", async (t) => {
+    const render = template("Hello #{name}!");
+    const stream = render({ name: "Stream" });
 
-test('Promise as a placeholder value', async (t) => {
-  const render = template('Async value: #{asyncValue}')
-  const result = await render({ 
-    asyncValue: Promise.resolve('resolved')
-  })
-  assert.strictEqual(result, 'Async value: resolved')
-})
+    // Create a writable stream to collect data
+    let collected = "";
+    const writable = new Writable({
+      write(chunk, encoding, callback) {
+        collected += chunk.toString();
+        callback();
+      },
+    });
 
-test('Numbers, booleans, and null values', async (t) => {
-  const render = template('Number: #{num}, Boolean: #{bool}, Null: #{nil}')
-  const result = await render({ 
-    num: 42, 
-    bool: true, 
-    nil: null 
-  })
-  assert.strictEqual(result, 'Number: 42, Boolean: true, Null: ')
-})
+    // Pipe and wait for completion
+    stream.pipe(writable);
+    await new Promise((resolve) => stream.on("end", resolve));
 
-test('Complex expressions', async (t) => {
-  const render = template('Result: #{a * 2 + (b > 10 ? 100 : 0)}')
-  
-  await t.test('Branch one', async () => {
-    const result = await render({ a: 5, b: 15 })
-    assert.strictEqual(result, 'Result: 110')
-  })
-  
-  await t.test('Branch two', async () => {
-    const result = await render({ a: 5, b: 5 })
-    assert.strictEqual(result, 'Result: 10')
-  })
-})
+    assert.strictEqual(collected, "Hello Stream!");
+  });
 
-test('Template with no placeholders', async (t) => {
-  const render = template('Static content')
-  const result = await render()
-  assert.strictEqual(result, 'Static content')
-})
+  it("Stream as a placeholder value", async (t) => {
+    const render = template("Content: #{content}");
 
-// TODO should we trigger error or comsider a?.missing?.property?
-// test('Error in expression evaluation', async (t) => {
-//   const render = template('Bad: #{a.missing.property}')
-//   await assert.rejects(async () => {
-//     await render({ a: {} })
-//   }, {
-//     name: 'TypeError'
-//   })
-// })
+    const contentStream = new Readable({
+      read() {
+        this.push("streamed content");
+        this.push(null);
+      },
+    });
 
-test('Using string literals in expressions', async (t) => {
-  const render = template('With quotes: #{name + " " + "quoted"}')
-  const result = await render({ name: 'String' })
-  assert.strictEqual(result, 'With quotes: String quoted')
-})
+    const result = await render({ content: contentStream });
+    assert.strictEqual(result, "Content: streamed content");
+  });
 
-test('Object method invocation in template', async (t) => {
-  const render = template('Uppercase: #{name.toUpperCase()}')
-  const result = await render({ name: 'convert' })
-  assert.strictEqual(result, 'Uppercase: CONVERT')
-})
+  it("Promise as a placeholder value", async (t) => {
+    const render = template("Async value: #{asyncValue}");
+    const result = await render({
+      asyncValue: Promise.resolve("resolved"),
+    });
+    assert.strictEqual(result, "Async value: resolved");
+  });
 
-test('Multiple template renderings with same engine', async (t) => {
-  const render = template('Hello #{name}!')
-  
-  const result1 = await render({ name: 'First' })
-  assert.strictEqual(result1, 'Hello First!')
-  
-  const result2 = await render({ name: 'Second' })
-  assert.strictEqual(result2, 'Hello Second!')
-})
+  it("Numbers, booleans, and null values", async (t) => {
+    const render = template("Number: #{num}, Boolean: #{bool}, Null: #{nil}");
+    const result = await render({
+      num: 42,
+      bool: true,
+      nil: null,
+    });
+    assert.strictEqual(result, "Number: 42, Boolean: true, Null: ");
+  });
 
-test('Empty template string', async (t) => {
-  const render = template('')
-  const result = await render()
-  assert.strictEqual(result, '')
-})
+  it("Complex expressions", async (t) => {
+    const render = template("Result: #{a * 2 + (b > 10 ? 100 : 0)}");
 
-// TODO this should work
-// test('Sequential placeholders', async (t) => {
-//   const render = template('#{a}#{b}#{c}')
-//   const result = await render({ a: 'Hello', b: ' ', c: 'World' })
-//   assert.strictEqual(result, 'Hello World')
-// })
+    await t.test("Branch one", async () => {
+      const result = await render({ a: 5, b: 15 });
+      assert.strictEqual(result, "Result: 110");
+    });
 
-test('Function returning another stream as placeholder', async (t) => {
-  const render = template('Content: #{getContent()}')
-  
-  const result = await render({ 
-    getContent: () => {
-      return new Readable({
-        read() {
-          this.push('nested stream')
-          this.push(null)
-        }
-      })
-    }
-  })
-  
-  assert.strictEqual(result, 'Content: nested stream')
-})
+    await t.test("Branch two", async () => {
+      const result = await render({ a: 5, b: 5 });
+      assert.strictEqual(result, "Result: 10");
+    });
+  });
 
-// TODO this should work
-// test('Math expressions', async (t) => {
-//   const render = template('Math: #{Math.floor(3.14159)}')
-//   const result = await render({})
-//   assert.strictEqual(result, 'Math: 3')
-// })
+  it("Template with no placeholders", async (t) => {
+    const render = template("Static content");
+    const result = await render();
+    assert.strictEqual(result, "Static content");
+  });
 
-test('Data object is optional', async (t) => {
-  const render = template('Static #{1 + 1}')
-  const result = await render() // No data object passed
-  assert.strictEqual(result, 'Static 2')
-})
+  // TODO should we trigger error or comsider a?.missing?.property?
+  // it('Error in expression evaluation', async (t) => {
+  //   const render = template('Bad: #{a.missing.property}')
+  //   await assert.rejects(async () => {
+  //     await render({ a: {} })
+  //   }, {
+  //     name: 'TypeError'
+  //   })
+  // })
 
+  it("Using string literals in expressions", async (t) => {
+    const render = template('With quotes: #{name + " " + "quoted"}');
+    const result = await render({ name: "String" });
+    assert.strictEqual(result, "With quotes: String quoted");
+  });
 
-// test('Advanced stream handling', async (t) => {
-//     await t.test('Nested streams', async () => {
-//       const render = template('Nested: #{outer}')
-      
-//       const innerStream = new Readable({
-//         read() {
-//           this.push('inner content')
-//           this.push(null)
-//         }
-//       })
-      
-//       const outerStream = new Readable({
-//         read() {
-//           this.push('begin-')
-//           this.push(innerStream)
-//           this.push('-end')
-//           this.push(null)
-//         }
-//       })
-      
-//       // This test will fail unless the template engine properly handles
-//       // stream objects within streams, which isn't typical behavior
-//       try {
-//         const result = await render({ outer: outerStream })
-//         console.log('RESULT', result)
-//         assert.strictEqual(result, 'Nested: begin-inner content-end')
-//       } catch (err) {
-//         // Alternatively, check that it fails predictably
-//         assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE')
-//       }
-//     })
-    
-//     await t.test('Transform stream as placeholder', async () => {
-//       const render = template('Transformed: #{transformer}')
-      
-//       const transformer = new Transform({
-//         transform(chunk, encoding, callback) {
-//           this.push(chunk.toString().toUpperCase())
-//           callback()
-//         }
-//       })
-      
-//       // Write to the transform stream after setting it as a placeholder
-//       setTimeout(() => {
-//         transformer.write('lowercase')
-//         transformer.end()
-//       }, 10)
-      
-//       const result = await render({ transformer })
-//       assert.strictEqual(result, 'Transformed: LOWERCASE')
-//     })
-//   })
-  
-  // test('Error handling', async (t) => {
+  it("Object method invocation in template", async (t) => {
+    const render = template("Uppercase: #{name.toUpperCase()}");
+    const result = await render({ name: "convert" });
+    assert.strictEqual(result, "Uppercase: CONVERT");
+  });
+
+  it("Multiple template renderings with same engine", async (t) => {
+    const render = template("Hello #{name}!");
+
+    const result1 = await render({ name: "First" });
+    assert.strictEqual(result1, "Hello First!");
+
+    const result2 = await render({ name: "Second" });
+    assert.strictEqual(result2, "Hello Second!");
+  });
+
+  it("Empty template string", async (t) => {
+    const render = template("");
+    const result = await render();
+    assert.strictEqual(result, "");
+  });
+
+  // TODO this should work
+  // it('Sequential placeholders', async (t) => {
+  //   const render = template('#{a}#{b}#{c}')
+  //   const result = await render({ a: 'Hello', b: ' ', c: 'World' })
+  //   assert.strictEqual(result, 'Hello World')
+  // })
+
+  it("Function returning another stream as placeholder", async (t) => {
+    const render = template("Content: #{getContent()}");
+
+    const result = await render({
+      getContent: () => {
+        return new Readable({
+          read() {
+            this.push("nested stream");
+            this.push(null);
+          },
+        });
+      },
+    });
+
+    assert.strictEqual(result, "Content: nested stream");
+  });
+
+  // TODO this should work
+  // it('Math expressions', async (t) => {
+  //   const render = template('Math: #{Math.floor(3.14159)}')
+  //   const result = await render({})
+  //   assert.strictEqual(result, 'Math: 3')
+  // })
+
+  it("Data object is optional", async (t) => {
+    const render = template("Static #{1 + 1}");
+    const result = await render(); // No data object passed
+    assert.strictEqual(result, "Static 2");
+  });
+
+  // it('Advanced stream handling', async (t) => {
+  //     await t.test('Nested streams', async () => {
+  //       const render = template('Nested: #{outer}')
+
+  //       const innerStream = new Readable({
+  //         read() {
+  //           this.push('inner content')
+  //           this.push(null)
+  //         }
+  //       })
+
+  //       const outerStream = new Readable({
+  //         read() {
+  //           this.push('begin-')
+  //           this.push(innerStream)
+  //           this.push('-end')
+  //           this.push(null)
+  //         }
+  //       })
+
+  //       // This test will fail unless the template engine properly handles
+  //       // stream objects within streams, which isn't typical behavior
+  //       try {
+  //         const result = await render({ outer: outerStream })
+  //         console.log('RESULT', result)
+  //         assert.strictEqual(result, 'Nested: begin-inner content-end')
+  //       } catch (err) {
+  //         // Alternatively, check that it fails predictably
+  //         assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE')
+  //       }
+  //     })
+
+  //     await t.test('Transform stream as placeholder', async () => {
+  //       const render = template('Transformed: #{transformer}')
+
+  //       const transformer = new Transform({
+  //         transform(chunk, encoding, callback) {
+  //           this.push(chunk.toString().toUpperCase())
+  //           callback()
+  //         }
+  //       })
+
+  //       // Write to the transform stream after setting it as a placeholder
+  //       setTimeout(() => {
+  //         transformer.write('lowercase')
+  //         transformer.end()
+  //       }, 10)
+
+  //       const result = await render({ transformer })
+  //       assert.strictEqual(result, 'Transformed: LOWERCASE')
+  //     })
+  //   })
+
+  // it('Error handling', async (t) => {
   //   await t.test('Function throwing error', async () => {
   //     const render = template('Error: #{throwError()}')
-      
+
   //     await assert.rejects(async () => {
-  //       await render({ 
+  //       await render({
   //         throwError: () => { throw new Error('Test error') }
   //       })
   //     }, {
   //       message: 'Test error'
   //     })
   //   })
-    
+
   //   await t.test('Stream emitting error', async () => {
   //     const render = template('Stream error: #{errorStream}')
-      
+
   //     const errorStream = new Readable({
   //       read() {
   //         this.emit('error', new Error('Stream error'))
   //       }
   //     })
-      
+
   //     await assert.rejects(async () => {
   //       await render({ errorStream })
   //     }, {
   //       message: 'Stream error'
   //     })
   //   })
-    
+
   //   await t.test('Promise rejection', async () => {
   //     const render = template('Promise rejection: #{failingPromise}')
-      
+
   //     await assert.rejects(async () => {
-  //       await render({ 
+  //       await render({
   //         failingPromise: Promise.reject(new Error('Promise failed'))
   //       })
   //     }, {
@@ -302,56 +303,56 @@ test('Data object is optional', async (t) => {
   //     })
   //   })
   // })
-  
-  // test('Edge cases', async (t) => {
+
+  // it('Edge cases', async (t) => {
   //   await t.test('Extremely large template', async () => {
   //     // Create a large template with many placeholders
   //     const placeholders = 1000
   //     let largeTemplate = ''
   //     let expectedResult = ''
-      
+
   //     for (let i = 0; i < placeholders; i++) {
   //       largeTemplate += `#{n${i}}`
   //       expectedResult += i.toString()
   //     }
-      
+
   //     // Create data object with all placeholders
   //     const data = {}
   //     for (let i = 0; i < placeholders; i++) {
   //       data[`n${i}`] = i
   //     }
-      
+
   //     const render = template(largeTemplate)
   //     const result = await render(data)
   //     assert.strictEqual(result, expectedResult)
   //   })
-    
+
   //   await t.test('Circular references in data', async () => {
   //     const render = template('Value: #{obj.value}')
-      
+
   //     const data = { obj: { value: 'test' } }
   //     // Create circular reference
   //     data.obj.self = data.obj
-      
+
   //     const result = await render(data)
   //     assert.strictEqual(result, 'Value: test')
   //   })
-    
+
   //   await t.test('Unicode characters', async () => {
   //     const render = template('Unicode: #{text}')
-      
-  //     const result = await render({ 
+
+  //     const result = await render({
   //       text: '你好 👋 こんにちは'
   //     })
-      
+
   //     assert.strictEqual(result, 'Unicode: 你好 👋 こんにちは')
   //   })
-    
+
   //   await t.test('Escaping placeholders', async () => {
   //     // The engine doesn't have native support for escaping.
   //     // This test documents expected behavior.
   //     const render = template('Literal #{: #{value}')
-      
+
   //     const result = await render({ value: 'test' })
   //     // Current behavior would try to evaluate '{: #{value' as an expression
   //     // This might error or produce unexpected results
@@ -363,23 +364,23 @@ test('Data object is optional', async (t) => {
   //     }
   //   })
   // })
-  
-  // test('Performance benchmark', async (t) => {
+
+  // it('Performance benchmark', async (t) => {
   //   const render = template('#{value}')
-    
+
   //   // Measure time for 1000 renderings
   //   const start = performance.now()
   //   for (let i = 0; i < 1000; i++) {
   //     await render({ value: 'test' })
   //   }
   //   const duration = performance.now() - start
-    
+
   //   // This is not a strict test, just informational
   //   console.log(`Performed 1000 renderings in ${duration}ms (${duration/1000}ms per render)`)
   //   assert.ok(true) // Just to have an assertion
   // })
-  
-  // test('Template literal placeholder injection', async (t) => {
+
+  // it('Template literal placeholder injection', async (t) => {
   //   await t.test('Template literals with expressions', async () => {
   //     const x = 10
   //     const y = 5
@@ -387,51 +388,51 @@ test('Data object is optional', async (t) => {
   //     const result = await tmpl
   //     assert.strictEqual(result, 'Sum: 15, Product: 50')
   //   })
-    
+
   //   await t.test('Template literals with functions', async () => {
   //     const getGreeting = () => 'Hello'
   //     const getName = () => 'Template'
-      
+
   //     const tmpl = template`${getGreeting()} ${getName()}!`
   //     const result = await tmpl
   //     assert.strictEqual(result, 'Hello Template!')
   //   })
-    
+
   //   await t.test('Template literals with nested templates', async () => {
   //     const innerTemplate = template`inner`
   //     const outerTemplate = template`outer ${await innerTemplate}`
-      
+
   //     const result = await outerTemplate
   //     assert.strictEqual(result, 'outer inner')
   //   })
   // })
-  
-  // test('Parse function tests', async (t) => {
+
+  // it('Parse function tests', async (t) => {
   //   // These tests are intended to verify the behavior of the internal parse function
-    
+
   //   await t.test('Parsing dot notation', async () => {
   //     const render = template('Test: #{a.b.c}')
   //     const result = await render({ a: { b: { c: 'nested' } } })
   //     assert.strictEqual(result, 'Test: nested')
   //   })
-    
+
   //   await t.test('Parsing array access', async () => {
   //     const render = template('Test: #{arr[0][1]}')
   //     const result = await render({ arr: [['a', 'b'], ['c', 'd']] })
   //     assert.strictEqual(result, 'Test: b')
   //   })
-    
+
   //   await t.test('Parsing string literals', async () => {
   //     const render = template('Test: #{"static string"}')
   //     const result = await render({})
   //     assert.strictEqual(result, 'Test: static string')
   //   })
-    
+
   //   await t.test('Parsing with regex', async () => {
   //     // Current implementation doesn't handle regex patterns in expressions
   //     // This test documents expected behavior
-  //     const render = template('Test: #{/test/.test(value)}')
-      
+  //     const render = template('Test: #{/test/.it(value)}')
+
   //     try {
   //       const result = await render({ value: 'test' })
   //       assert.strictEqual(result, 'Test: true')
@@ -441,12 +442,12 @@ test('Data object is optional', async (t) => {
   //     }
   //   })
   // })
-  
-  // test('Using the template engine in different ways', async (t) => {
+
+  // it('Using the template engine in different ways', async (t) => {
   //   await t.test('Streaming to file', async () => {
   //     const render = template('File content with #{value}')
   //     const stream = render({ value: 'data' })
-      
+
   //     // Simulate writing to file with a proper Writable stream
   //     let fileContent = ''
   //     const { Writable } = await import('node:stream')
@@ -456,23 +457,23 @@ test('Data object is optional', async (t) => {
   //         callback()
   //       }
   //     })
-      
+
   //     stream.pipe(fileStream)
   //     await new Promise(resolve => stream.on('end', resolve))
-      
+
   //     assert.strictEqual(fileContent, 'File content with data')
   //   })
-    
+
   //   await t.test('Async iteration of template result', async () => {
   //     const render = template('Before #{middle} after')
   //     const stream = render({ middle: 'content' })
-      
+
   //     let result = ''
   //     for await (const chunk of stream) {
   //       result += chunk
   //     }
-      
+
   //     assert.strictEqual(result, 'Before content after')
   //   })
   // })
-  
+});

--- a/packages/sensai/src/utils/template.ts
+++ b/packages/sensai/src/utils/template.ts
@@ -1,7 +1,7 @@
-import { Readable, Stream, Transform, isReadable } from 'node:stream'
+import { Readable, Stream, Transform, isReadable } from "node:stream";
 
 // TODO we should add validation at the template level
-// ex: #{} is required ?{} is optional 
+// ex: #{} is required ?{} is optional
 // TODO we should display a useful callstack if any error in template
 // TODO we should have options to cache data
 
@@ -12,47 +12,53 @@ import { Readable, Stream, Transform, isReadable } from 'node:stream'
  */
 
 export default (
-  template: string | TemplateStringsArray, 
+  template: string | TemplateStringsArray,
   ...values: any[]
 ): any => {
-  if (typeof template === 'string') {
-    const [ chunks, patterns ] = compile(template) // TODO do something with params
+  if (typeof template === "string") {
+    const [chunks, patterns, params] = compile(template); // TODO do something with params
     //const readable = createReadable(chunks)
-    return (data: Record<string, any> = {}) => {
-      const stream = createReadable(chunks).pipe(createTransform((i) => {
-        const cb = patterns[i]
-        if (cb) return cb(data)
-      }))
-      return Object.assign(stream, thenable(stream))
-    }
+    const compiledTemplate = (data: Record<string, any> = {}) => {
+      const stream = createReadable(chunks).pipe(
+        createTransform((i) => {
+          const cb = patterns[i];
+          if (cb) return cb(data);
+        })
+      );
+      return Object.assign(stream, thenable(stream));
+    };
+    compiledTemplate.params = params;
+    return compiledTemplate;
   } else {
-    const stream = createReadable(template)
-      .pipe(createTransform((i) => values[i]))
-    return Object.assign(stream, thenable(stream))
+    // template literal
+    const stream = createReadable(template).pipe(
+      createTransform((i) => values[i])
+    );
+    return Object.assign(stream, thenable(stream));
   }
-}
+};
 
 /**
  * Extract chunks of strings from a template as well as the values
  * to insert.
  */
 
-const compile = (str: string): [string[], Function[], string[]] => {
-  const strings: string[] = []
-  const patterns: Function[] = []
-  const params: string[] = []
-  const regex = /#\{([^}]+)\}/g
+export const compile = (str: string): [string[], Function[], string[]] => {
+  const strings: string[] = [];
+  const patterns: Function[] = [];
+  const params: string[] = [];
+  const regex = /#\{([^}]+)\}/g;
   let match;
-  let idx = 0
+  let idx = 0;
   while ((match = regex.exec(str)) !== null) {
-    const { index } = match
-    strings.push(str.slice(idx, index))
-    idx = index + match[0].length
-    patterns.push(new Function('data', `return ${parse(match[1], params)}`))
+    const { index } = match;
+    strings.push(str.slice(idx, index));
+    idx = index + match[0].length;
+    patterns.push(new Function("data", `return ${parse(match[1], params)}`));
   }
-  strings.push(str.slice(idx))
-  return [strings, patterns, params]
-}
+  strings.push(str.slice(idx));
+  return [strings, patterns, params];
+};
 
 /**
  * Create a readable stream from chunks of strings.
@@ -62,45 +68,45 @@ const createReadable = (chunks: string[] | TemplateStringsArray) => {
   return new Readable({
     read() {
       for (const chunk of chunks) {
-        this.push(chunk)
+        this.push(chunk);
       }
-      this.push(null)
-    }
-  })
-}
+      this.push(null);
+    },
+  });
+};
 
 /**
- * Create transform stream used to inject data between chunks 
+ * Create transform stream used to inject data between chunks
  * of strings.
- * 
- * @notes the transform is called one extra time with an undefined value 
+ *
+ * @notes the transform is called one extra time with an undefined value
  * as there is always one more chunk than values.
  */
 
 const createTransform = (cb: (index: number) => any) => {
-  let i = 0
+  let i = 0;
   return new Transform({
     async transform(chunk, _, callback) {
-      this.push(chunk)
-      let value = await cb(i++)
-      if (typeof value === 'function') value = value()
+      this.push(chunk);
+      let value = await cb(i++);
+      if (typeof value === "function") value = value();
       if (isReadable(value)) {
-        await promisify(value, (buff: Buffer) => this.push(buff))
+        await promisify(value, (buff: Buffer) => this.push(buff));
       } else {
-        const buff = await value
-        this.push(buff == null ? '' : String(buff))
+        const buff = await value;
+        this.push(buff == null ? "" : String(buff));
       }
-      callback()
-    }
-  })
-}
+      callback();
+    },
+  });
+};
 
 /**
  * Forbidden characters.
  * @type {Array}
  */
 
-const forbidden = ['"', '.', "'"]
+const forbidden = ['"', ".", "'"];
 
 /**
  * Parse expression and replace
@@ -116,12 +122,15 @@ const forbidden = ['"', '.', "'"]
  */
 
 const parse = (str: string, arr: string[]) => {
-  return str.replace(/\.\w+|"[^"]*"|'[^']*'|\/([^/]+)\/|[a-zA-Z_]\w*/g, (expr) => {
-    if (forbidden.indexOf(expr[0]) > -1) return expr
-    if (!~arr.indexOf(expr)) arr.push(expr)
-    return 'data.' + expr
-  })
-}
+  return str.replace(
+    /\.\w+|"[^"]*"|'[^']*'|\/([^/]+)\/|[a-zA-Z_]\w*/g,
+    (expr) => {
+      if (forbidden.indexOf(expr[0]) > -1) return expr;
+      if (!~arr.indexOf(expr)) arr.push(expr);
+      return "data." + expr;
+    }
+  );
+};
 
 /**
  * Create a "thenable" object from a stream.
@@ -131,29 +140,23 @@ const parse = (str: string, arr: string[]) => {
 const thenable = (stream: Stream) => {
   return {
     then: (resolve: (value: string) => void, reject: (reason: any) => void) => {
-      let result = ''
+      let result = "";
       // TODO is there a way to merge pthenable and promisify?
       stream
-        .on('data', (chunk) => result += chunk)
-        .on('error', reject)
-        .on('end', () => resolve(result))
-    }
-  }
-}
+        .on("data", (chunk) => (result += chunk))
+        .on("error", reject)
+        .on("end", () => resolve(result));
+    },
+  };
+};
 
 /**
  * Resolve promise whenever a readable stream is done.
  * @param push function called on data
  */
 
-const promisify = (
-  stream: Readable, 
-  push: (buff: Buffer) => void
-) => {
-   return new Promise((resolve, reject) => {
-    stream
-      .on('data', push)
-      .on('error', reject)
-      .on('end', resolve)
-  })
-}
+const promisify = (stream: Readable, push: (buff: Buffer) => void) => {
+  return new Promise((resolve, reject) => {
+    stream.on("data", push).on("error", reject).on("end", resolve);
+  });
+};

--- a/packages/sensai/src/utils/template.ts
+++ b/packages/sensai/src/utils/template.ts
@@ -13,7 +13,7 @@ import { Readable, Stream, Transform, isReadable } from "node:stream";
 
 export default (
   template: string | TemplateStringsArray,
-  ...values: any[]
+  ...values: unknown[]
 ): any => {
   if (typeof template === "string") {
     const [chunks, patterns, params] = compile(template); // TODO do something with params
@@ -27,7 +27,17 @@ export default (
       );
       return Object.assign(stream, thenable(stream));
     };
-    compiledTemplate.params = params;
+    compiledTemplate.schema = params.reduce(
+      (acc, param) => {
+        const { properties } = acc;
+        properties[param] = { type: "string" };
+        return acc;
+      },
+      {
+        type: "object",
+        properties: {},
+      }
+    );
     return compiledTemplate;
   } else {
     // template literal


### PR DESCRIPTION
We should generate a basic json schema of prompt parameters (i.e `#{param}`). The parameters returned by our template engine are not nested for now and are strings. It's just a start :) 