### PR TITLE
refactor(cli): replace agent directory detection with CLI flag

### DIFF
--- a/packages/sensai/src/bin/sensai-build.ts
+++ b/packages/sensai/src/bin/sensai-build.ts
@@ -7,11 +7,10 @@ export default new commander.Command()
   .description(
     "Description:\n  Compiles and optimize sensai project for production deployment."
   )
-  .argument("[dir]", "represents the API directory", "api")
-  .usage("<dir>")
-  .action(async (apiDir: string) => {
+  .option("--agent", "build in agent mode")
+  .action(async (options: { agent: boolean }) => {
     const { default: command } = await import("@/src/commands/build");
     await command({
-      apiDir,
+      apiDir: "api",
     });
   });

--- a/packages/sensai/src/bin/sensai-dev.ts
+++ b/packages/sensai/src/bin/sensai-dev.ts
@@ -2,8 +2,6 @@ import * as commander from "commander";
 import { DEV_SERVER_DEFAULT_PORT, SENSAI_COMMAND } from "@/src/constants";
 import getPort from "@/src/utils/port";
 import command from "@/src/commands/dev";
-import { hasFile } from "@/src/utils/fs";
-import { join } from "node:path";
 import cli from "@/src/lib/cli";
 import { SENSAI_MODE } from "@/src/constants";
 
@@ -14,25 +12,17 @@ import { SENSAI_MODE } from "@/src/constants";
 const initializeDevServer = async (options: {
   port: string;
   watch: boolean;
+  agent: boolean;
 }) => {
-  const mode = await detectMode();
+  const mode = options.agent ? SENSAI_MODE.AGENT : SENSAI_MODE.API;
   const port = await getPort(Number(options.port));
   await cli(mode, port);
   await command({
     port,
-    apiDir: mode,
+    apiDir: "api",
     watch: options.watch,
     cwdPath: process.cwd(),
   });
-};
-
-const detectMode = async (): Promise<SENSAI_MODE> => {
-  const root = process.cwd();
-  if (await hasFile(join(root, "agent"))) return SENSAI_MODE.AGENT;
-  if (await hasFile(join(root, "api"))) return SENSAI_MODE.API;
-  throw new Error(
-    'No "agent" or "api" directory found in the current working directory.'
-  );
 };
 
 // create dev command
@@ -45,5 +35,6 @@ export default new commander.Command()
     process.env.PORT || DEV_SERVER_DEFAULT_PORT
   )
   .option("--no-watch", "disable hot reload")
+  .option("--agent", "enable agent mode")
   .usage("-p <port number>")
   .action(initializeDevServer);


### PR DESCRIPTION
Remove automatic detection of agent/api directories in favor of explicit --agent flag. Both dev and build commands now always use "api" directory but can enable agent mode behavior via the flag.

- Remove detectMode() function and related directory detection logic
- Add --agent flag to both sensai dev and sensai build commands
- Always use "api" as working directory regardless of mode
- Agent mode only affects CLI behavior and future bundling options